### PR TITLE
core - support python versions < 3.11

### DIFF
--- a/src/nsisunbz2/core.py
+++ b/src/nsisunbz2/core.py
@@ -271,7 +271,7 @@ class Bz2Decompress:
             if not len(next_in):
                 raise RuntimeError(f'BZ_DATA_ERROR: {err} not found')
 
-            self.bsbuff = (self.bsbuff << 8) | int.from_bytes(next_in)
+            self.bsbuff = (self.bsbuff << 8) | int.from_bytes(next_in, byteorder='big')
             self.bslive += 8
 
     def _block_header(self):


### PR DESCRIPTION
explicitly add default arg value from Python 3.11+
close #1

[NO_TRAIN]::